### PR TITLE
Use Rainbow presenter instead of string extension

### DIFF
--- a/lib/ascii-image.rb
+++ b/lib/ascii-image.rb
@@ -62,7 +62,7 @@ class ASCII_Image
         
         # Get the pixel array
         image.each_pixel do |pixel, col, row|
-            print " ".background(pixel.red, pixel.green, pixel.blue)
+            print Rainbow(" ").background(pixel.red, pixel.green, pixel.blue)
             
             if (col % (width - 1) == 0) and (col != 0)
                 print "\n"


### PR DESCRIPTION
The Rainbow library does not currently extend `String` by default, and raises exception on a fresh installed version of this gem. In Rainbow v2, you could add string extensions (active support style), and in version 3, they leverage refinements. Neither seems necessary since it's really straight forward to just use `Rainbow(' ').bg` in this example.